### PR TITLE
Change homepage dropdowns in navbar

### DIFF
--- a/client/src/components/navbar/NavigationBar.js
+++ b/client/src/components/navbar/NavigationBar.js
@@ -67,11 +67,14 @@ function NavigationBar() {
 						>
 							<div className="dropdown">
 								<div className="dropdown-content">
-									<Link className="dropdown-link" to="/about">
+									<Link className="dropdown-link" to="/homepage" state={{ option: 1}}>
 										&gt; About
 									</Link>
-									<Link className="dropdown-link" to="/opportunity">
-										&gt; Opportunity
+									<Link className="dropdown-link" to="/homepage" state={{ option: 2}}>
+										&gt; News
+									</Link>
+									<Link className="dropdown-link" to="/homepage" state={{ option: 3}}>
+										&gt; Contact Us
 									</Link>
 								</div>
 								<Link

--- a/client/src/components/navbar/NavigationBar.js
+++ b/client/src/components/navbar/NavigationBar.js
@@ -67,13 +67,25 @@ function NavigationBar() {
 						>
 							<div className="dropdown">
 								<div className="dropdown-content">
-									<Link className="dropdown-link" to="/homepage" state={{ option: 1}}>
+									<Link
+										className="dropdown-link"
+										to="/homepage"
+										state={{ option: 1 }}
+									>
 										&gt; About
 									</Link>
-									<Link className="dropdown-link" to="/homepage" state={{ option: 2}}>
+									<Link
+										className="dropdown-link"
+										to="/homepage"
+										state={{ option: 2 }}
+									>
 										&gt; News
 									</Link>
-									<Link className="dropdown-link" to="/homepage" state={{ option: 3}}>
+									<Link
+										className="dropdown-link"
+										to="/homepage"
+										state={{ option: 3 }}
+									>
 										&gt; Contact Us
 									</Link>
 								</div>


### PR DESCRIPTION
Remove "Opportunity" dropdown from navbar under `Home` button because homepage will no longer have "Opportunity" section. Add   "News" and "Contact Us" dropdowns for Homepage on navbar.

![Screenshot 2022-09-05 231443](https://user-images.githubusercontent.com/78233689/188560148-8195deab-2ab6-45f8-a114-a0eb3e0c2432.png)
