### PR TITLE
fix horizontal scroll offset

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -4,8 +4,6 @@
 
 html,
 body {
-	height: 100vh;
-	width: 100vw;
 	margin: 0;
 	padding: 0;
 	background-color: #21262d;


### PR DESCRIPTION
found that all pages had a horizontal scroll at the bottom, which was caused by adding 100vw and 100vh in app.css. By removing these the ui functions normally.