### PR TITLE
controller framework and tests for tag routes

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,38 @@
+const express = require("express")
+const app = express()
+// const passport = require("passport")
+// const magicLogin = require("passport-magic-login")
+const path = require("path")
+require("dotenv/config")
+
+// Import models
+// Notes: remove model imports won't add schemas to cs_club database on Linux
+// Will remove model imports once importing routes
+require("./models/events/events-model")
+require("./models/projects/projects-model")
+require("./models/organizations/orgs-model")
+
+// Parsing
+app.use(express.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.static(path.join(path.resolve("./"), "public")))
+
+// Import Routes
+const imagesRoute = require("./routes/images/images-route")
+const tagsRoute = require("./routes/tags/tags-route")
+// const eventsRoute = require("./routes/events/events-route")
+// const projectsRoute = require("./routes/projects/projects-route")
+// const tutorialsRoute = require("./routes/tutorials/tutorials-route")
+// const readingsRoute = require("./routes/readings/readings-route")
+// const organizationsRoute = require("./routes/organizations/orgs-route")
+
+// Use Routes
+const apiPath = "api"
+app.use(`/${apiPath}/images`, imagesRoute)
+app.use(`/${apiPath}/tags`, tagsRoute)
+
+app.get("/", (req, res) => {
+  res.send("GET request to the homepage")
+})
+
+module.exports = app

--- a/backend/app.js
+++ b/backend/app.js
@@ -32,7 +32,7 @@ app.use(`/${apiPath}/images`, imagesRoute)
 app.use(`/${apiPath}/tags`, tagsRoute)
 
 app.get("/", (req, res) => {
-  res.send("GET request to the homepage")
+    res.send("GET request to the homepage")
 })
 
 module.exports = app

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------//
+//                            BACKEND CONFIGS                       //
+// ----------------------------------------------------------------//
+//
+// Descriptions:
+//    - Store values that are used in multiple files
+//    - Do NOT store vulnerable values such as SECRET KEY, or TOKEN
+
+module.exports = {
+    // Pagination
+    // Size of items to query
+    defaultMaxPageSize: 100,
+
+    // Size of items to render
+    defaultPageSize: 10,
+}

--- a/backend/controllers/tags/tags-controller.js
+++ b/backend/controllers/tags/tags-controller.js
@@ -1,1 +1,6 @@
-// const tags = require("../../models/tags/tags-model")
+const Controller = require("../../framework/controller")
+const { TagsModel } = require("../../models/tags/tags-model")
+
+const TagsController = new Controller(TagsModel)
+
+module.exports = { TagsController }

--- a/backend/framework/controller.js
+++ b/backend/framework/controller.js
@@ -26,6 +26,16 @@ class Controller {
         this.Model = model
     }
 
+    //
+    // Get all instances in batch using cursor pagination
+    // Handle GET request
+    //
+    // This function does not handle random page access
+    // For efficiency, it queries data in batch
+    // This allow frontend to render pagination from a served batch
+    // Whenever frontend exceeds the limit page based on the batch size,
+    // Frontend must handle a request to push a new batch
+    //
     async getAll(req, res) {
         const reqSize = parseInt(req.query.size) // get query size from query params
         const sortOrder = { _id: -1 } // sort in descending order by default
@@ -67,6 +77,7 @@ class Controller {
                 return res.status(400).json({ error })
             })
 
+        // Update next and prev cursors
         let firstId, lastId
         let hasNext = false
         let hasPrev = false
@@ -92,18 +103,24 @@ class Controller {
         })
     }
 
-    // GET - Return a specific instance
+    //
+    // Retrieve a data instance by id
+    // Handle GET request that contains id param.
+    //
     async getOne(req, res) {
         const instance = await this.Model.findById(req.query.id)
 
         if (!instance) {
-            return res.status(204).json({ Error: "Item does not exist" })
+            return res.status(204).json({ Error: "item does not exist" })
         }
 
         return res.status(200).json(instance)
     }
 
-    // POST - Add a new instance
+    //
+    // Add a new data instance to the database.
+    // Handle POST request.
+    //
     async create(req, res) {
         if (!req.body) {
             return res
@@ -128,10 +145,13 @@ class Controller {
         })
     }
 
-    // PATCH - Update information of an instance
+    //
+    // Partially or fully update values for a data instance by id.
+    // Handle PATCH request.
+    //
     async update(req, res) {
         if (!req.query.id) {
-            return res.status(400).json({ error: "Id is required" })
+            return res.status(400).json({ error: "id is required" })
         }
 
         await this.Model.findByIdAndUpdate(req.query.id, req.body)
@@ -147,22 +167,20 @@ class Controller {
         })
     }
 
-    // DELETE - Remove an instance
+    //
+    // Remove a data instance from the database by id.
+    // Handle DELETE request.
+    //
     async delete(req, res) {
         if (!req.query.id) {
             return res.status(400).json({ error: "id is required" })
         }
 
-        const deletedData = await this.Model.findByIdAndDelete(
-            req.query.id,
-            req.body
-        )
-            .then((data) => {
-                return data
-            })
-            .catch((error) => {
+        await this.Model.findByIdAndDelete(req.query.id, req.body).catch(
+            (error) => {
                 return res.status(400).json({ error })
-            })
+            }
+        )
 
         return res
             .status(200)

--- a/backend/framework/controller.js
+++ b/backend/framework/controller.js
@@ -1,131 +1,172 @@
-// --------------------------------------------------------------------------//
-//                           Controller Framwork                             //
-// --------------------------------------------------------------------------//
+// ----------------------------------------------------------------------------------//
+//                                Controller Framework                               //
+// ----------------------------------------------------------------------------------//
 // Descriptions:
-//      - Controller Framework reduces redundancy same logics among data models
-//      when implementing Express js REST API
-//      - This framework won't support user and user-related models at the moment
+//      - Controller Framework reduces the redundancy when implementing REST API
+//          using Express JS
+//      - This framework won't support user or user-related models at the moment
+//      - The framework use query string parameters in api route for flexibility
 //
 //  Usage:
-//      1. In controller file of a data model, import Controller class
-//      2. Create an instance of the class by assign the data model
-//      3. Export the class
-//      4. Import the controller instance to the route file
-//      5. Add a member function that is suitable for an API method (GET, PUT, PATCH,.. etc)
-//          of the routing function
+//      1. Import Controller class to controller file via the directory
+//          controllers/<model_name>/<model_name>-controller.js
+//      2. Create an instance of the class by assigning the data model
+//      3. Export the controller instance
+//      4. Import the controller instance to the route file via the directory
+//          routes/<model_name>/<model_name>-route.js
+//      5. Add a member function that is suitable for an API method
+//          (GET, PUT, PATCH,.. etc) of the routing function
+//      6. Import the model route to index.js under "Import route" section
+//          and add use route
+
+const config = require("../config")
 
 class Controller {
     constructor(model) {
         this.Model = model
     }
 
-    // GET - Respond with limited mutiple instances
-    // Use cursor pagination for efficient query
-    // Retrieve descending order to show latest items on top
     async getAll(req, res) {
-        let prev = req.query.prev
+        const reqSize = parseInt(req.query.size) // get query size from query params
+        const sortOrder = { _id: -1 } // sort in descending order by default
+        let size = config.defaultPageSize
         let next = req.query.next
-        let size = parseInt(req.query.size) || 10
-        if (size < 1) {
-            size = 10
+        let prev = req.query.prev
+        const query = {}
+
+        // Count all instances
+        const total = await this.Model.find().count("_id")
+
+        if (reqSize > config.defaultMaxPageSize) {
+            size = config.defaultMaxPageSize
+        } else if (reqSize > size) {
+            size = reqSize
         }
-        if (size > 50) {
-            size = 10
+
+        if (req.query.last) {
+            sortOrder._id = 1
+            size = total % size === 0 ? size : total % size
+        } else if (next) {
+            query._id = { $lt: next }
+        } else if (prev) {
+            query._id = { $gt: prev }
+            sortOrder._id = 1
         }
 
-        try {
-            let instances = null
-
-            // Initial query
-            if (!prev && !next) {
-                instances = await this.Model.find()
-                    .sort({ _id: -1 })
-                    .limit(size + 1)
-                if (instances.length === size + 1) {
-                    instances.pop()
-                    prev = null
-                    next = instances[size - 1]._id
-                } else {
-                    next = prev = null
+        const data = await this.Model.find(query)
+            .sort(sortOrder)
+            .limit(size)
+            .then((data) => {
+                if (prev || req.query.last) {
+                    return data.reverse()
                 }
-            }
-            // Follow-up query
-            else {
-                // set 1 for ascending order to prevent mongoose from retrieving
-                // items from beginning if in descending order
-                const order = next ? -1 : 1
-                const queryCondition = next ? { $lt: next } : { $gt: prev }
 
-                instances = await this.Model.find({ _id: queryCondition })
-                    .sort({ _id: order })
-                    .limit(size + 1)
-
-                if (instances.length === size + 1) {
-                    instances.pop()
-                    if (next) {
-                        prev = instances[0]._id
-                        next = instances[size - 1]._id
-                    } else {
-                        prev = instances[size - 1]._id
-                        next = instances[0]._id
-                        instances.reverse()
-                    }
-                } else {
-                    if (next) {
-                        prev = instances[0]._id
-                        next = null
-                    } else {
-                        prev = null
-                        next = instances[size - 1]._id
-                        instances.reverse()
-                    }
-                }
-            }
-
-            return res.status(200).send({
-                data: instances,
-                cursors: {
-                    prev,
-                    next,
-                },
+                return data
             })
-        } catch (err) {
-            console.log(err)
-            return res.send(err)
+            .catch((error) => {
+                return res.status(400).json({ error })
+            })
+
+        let firstId, lastId
+        let hasNext = false
+        let hasPrev = false
+
+        if (data.length) {
+            firstId = data[0]._id
+            lastId = data[data.length - 1]._id
+            hasPrev = await this.Model.exists({ _id: { $gt: firstId } })
+            hasNext = await this.Model.exists({ _id: { $lt: lastId } })
         }
+
+        next = hasNext ? lastId : null
+        prev = hasPrev ? firstId : null
+
+        return res.status(200).json({
+            total,
+            size,
+            cursors: {
+                prev,
+                next,
+            },
+            data,
+        })
     }
 
-    // GET - Respond with specific instance
+    // GET - Return a specific instance
     async getOne(req, res) {
-        console.log(req.query.id)
-        try {
-            const instance = await this.Model.findById(req.query.id)
-            res.status(200).send(instance)
-        } catch (err) {
-            res.send(err)
+        const instance = await this.Model.findById(req.query.id)
+
+        if (!instance) {
+            return res.status(204).json({ Error: "Item does not exist" })
         }
+
+        return res.status(200).json(instance)
     }
 
-    // POST - Add a new model instance
+    // POST - Add a new instance
     async create(req, res) {
-        const instance = this.Model(req.body)
-        try {
-            const newInstance = await instance.save()
-            res.status(201).send(newInstance)
-            console.log("a new instance was added to database")
-        } catch (err) {
-            res.send(err)
+        if (!req.body) {
+            return res
+                .status(400)
+                .json({ error: "Request body has no content" })
         }
+
+        const existedData = await this.Model.findOne(req.body)
+
+        if (existedData) {
+            return res.status(403).json({ error: "Data already existed" })
+        }
+
+        const instance = this.Model(req.body)
+        const newInstance = await instance.save().catch((error) => {
+            return res.status(400).json({ error })
+        })
+
+        return res.status(201).json({
+            message: "A new instance was added to database",
+            data: newInstance,
+        })
     }
 
-    // PATCH - Update information for a model instance
+    // PATCH - Update information of an instance
     async update(req, res) {
-        console.log(req)
+        if (!req.query.id) {
+            return res.status(400).json({ error: "Id is required" })
+        }
+
+        await this.Model.findByIdAndUpdate(req.query.id, req.body)
+            .then((data) => {
+                return data
+            })
+            .catch((error) => {
+                return res.status(400).json({ error })
+            })
+
+        return res.status(202).json({
+            message: "Data was updated successfully",
+        })
     }
 
-    // DELETE - Remove a model instance
+    // DELETE - Remove an instance
     async delete(req, res) {
-        console.log(req)
+        if (!req.query.id) {
+            return res.status(400).json({ error: "id is required" })
+        }
+
+        const deletedData = await this.Model.findByIdAndDelete(
+            req.query.id,
+            req.body
+        )
+            .then((data) => {
+                return data
+            })
+            .catch((error) => {
+                return res.status(400).json({ error })
+            })
+
+        return res
+            .status(200)
+            .json({ message: "Data was deleted successfully" })
     }
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,53 +1,20 @@
-const express = require("express")
-const app = express()
+const app = require("./app")
 const mongoose = require("mongoose")
-// const passport = require("passport")
-// const magicLogin = require("passport-magic-login")
-const path = require("path")
 const checkMongoStatus = require("./utils/check-mongo-status")
-const PORT = process.env.PORT || 8000
 const MONGO_URL = process.env.MONGO_URL || "mongodb://localhost/occ-csc"
+const PORT = process.env.PORT || 8000
 require("dotenv/config")
 
 // Connect datbase and create collection
 mongoose
-    .connect(MONGO_URL)
+    .connect(MONGO_URL, { useNewUrlParser: true })
     .then(() => checkMongoStatus.getStatus())
     .catch((error) => {
         console.log(error)
     })
 
-// Import models
-// Notes: remove model imports won't add schemas to cs_club database on Linux
-// Will remove model imports once importing routes
-require("./models/events/events-model")
-require("./models/tags/tags-model")
-require("./models/projects/projects-model")
-require("./models/organizations/orgs-model")
-
-// Parsing
-app.use(express.urlencoded({ extended: true }))
-app.use(express.json())
-app.use(express.static(path.join(path.resolve("./"), "public")))
-
-// Import Routes
-const imagesRoute = require("./routes/images/images-route")
-const tagsRoute = require("./routes/tags/tags-route")
-// const eventsRoute = require("./routes/events/events-route")
-// const projectsRoute = require("./routes/projects/projects-route")
-// const tutorialsRoute = require("./routes/tutorials/tutorials-route")
-// const readingsRoute = require("./routes/readings/readings-route")
-// const organizationsRoute = require("./routes/organizations/orgs-route")
-
-// Use Routes
-app.use("/images", imagesRoute)
-app.use("/tags", tagsRoute)
-
-app.get("/", (req, res) => {
-    res.send("GET request to the homepage")
-})
-
 // Run server
 app.listen(PORT, () => {
     console.log(`Running backend server on: http://127.0.0.1:${PORT}`)
 })
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -17,4 +17,3 @@ mongoose
 app.listen(PORT, () => {
     console.log(`Running backend server on: http://127.0.0.1:${PORT}`)
 })
-

--- a/backend/models/events/events-model.test.js
+++ b/backend/models/events/events-model.test.js
@@ -1,5 +1,5 @@
 const EventsModel = require("./events-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 const testEvent1 = {

--- a/backend/models/organizations/orgs-model.test.js
+++ b/backend/models/organizations/orgs-model.test.js
@@ -1,6 +1,6 @@
 const OrgsModel = require("./orgs-model")
 const { TagsModel } = require("../tags/tags-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 const testTags = [

--- a/backend/models/projects/projects-model.test.js
+++ b/backend/models/projects/projects-model.test.js
@@ -1,6 +1,6 @@
 // const mongoose = require("mongoose")
 const ProjectsModel = require("./projects-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 const testProject1 = {

--- a/backend/models/readings/readings-model.test.js
+++ b/backend/models/readings/readings-model.test.js
@@ -1,6 +1,6 @@
 // const mongoose = require("mongoose")
 // const readingsModel = require("./readings-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 

--- a/backend/models/tags/tags-model.js
+++ b/backend/models/tags/tags-model.js
@@ -9,6 +9,7 @@ const tagSchema = new Schema({
     created_at: {
         type: Date,
         require: true,
+        default: Date.now(),
     },
 })
 

--- a/backend/models/tags/tags-model.js
+++ b/backend/models/tags/tags-model.js
@@ -4,11 +4,12 @@ const { Schema } = mongoose
 const tagSchema = new Schema({
     title: {
         type: String,
+        unique: true,
         required: true,
     },
     created_at: {
         type: Date,
-        require: true,
+        immutable: true,
         default: Date.now(),
     },
 })

--- a/backend/models/tags/tags-model.test.js
+++ b/backend/models/tags/tags-model.test.js
@@ -1,5 +1,5 @@
 const { TagsModel } = require("./tags-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 const testTagCollection = [
@@ -23,7 +23,7 @@ afterEach(async () => await db.clearDatabase())
 afterAll(async () => await db.closeDatabase())
 
 // Add your test here
-describe("Events Model Tests", () => {
+describe("Tags Model Tests", () => {
     test("Database Has Tags Model", () => {
         expect(TagsModel).toBeDefined()
     })

--- a/backend/models/tutorials/tutorials-model.test.js
+++ b/backend/models/tutorials/tutorials-model.test.js
@@ -1,6 +1,6 @@
 // const mongoose = require("mongoose")
 const TutorialsModel = require("./tutorials-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 const { TagsModel } = require("../tags/tags-model")
 
 // Define test instances here

--- a/backend/models/user-action/user-action-model.test.js
+++ b/backend/models/user-action/user-action-model.test.js
@@ -1,6 +1,6 @@
 const { UserModel } = require("../user/user-model")
 const { UserActionModel } = require("./user-action-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // Define test instances here
 const testUser1 = {

--- a/backend/models/user/user-model.test.js
+++ b/backend/models/user/user-model.test.js
@@ -1,5 +1,5 @@
 const { UserModel } = require("./user-model")
-const db = require("../db-test-setup")
+const db = require("../../utils/test/db-test-setup")
 
 // TODO: Add user activity tests per user
 

--- a/backend/routes/tags/tags-route.js
+++ b/backend/routes/tags/tags-route.js
@@ -3,8 +3,10 @@ const router = express.Router()
 const { TagsController } = require("../../controllers/tags/tags-controller")
 
 // Add your code here
-router.get("/", (req, res) => TagsController.getAll(req, res))
+router.get("", (req, res) => TagsController.getAll(req, res))
 router.get("/tag", (req, res) => TagsController.getOne(req, res))
-router.post("/", (req, res) => TagsController.create(req, res))
+router.post("", (req, res) => TagsController.create(req, res))
+router.patch("/tag", (req, res) => TagsController.update(req, res))
+router.delete("/tag", (req, res) => TagsController.delete(req, res))
 
 module.exports = router

--- a/backend/routes/tags/tags-route.js
+++ b/backend/routes/tags/tags-route.js
@@ -1,4 +1,10 @@
-// const express = require("express")
-// const router = express.Router()
+const express = require("express")
+const router = express.Router()
+const { TagsController } = require("../../controllers/tags/tags-controller")
 
 // Add your code here
+router.get("/", (req, res) => TagsController.getAll(req, res))
+router.get("/tag", (req, res) => TagsController.getOne(req, res))
+router.post("/", (req, res) => TagsController.create(req, res))
+
+module.exports = router

--- a/backend/routes/tags/tags-route.test.js
+++ b/backend/routes/tags/tags-route.test.js
@@ -1,9 +1,285 @@
-// const supertest = require("supertest")
-// const tutorialsRoute = require("./tags-route")
+const supertest = require("supertest")
+const app = require("../../app")
+const request = supertest(app)
+const { TagsModel } = require("../../models/tags/tags-model")
+const tagsTestCases = require("../../utils/test/data/tags.data.json")
+const db = require("../../utils/test/db-test-setup")
+const config = require("../../config")
 
 // Add your test here
-describe("Dummy test", () => {
-    test("Dummy test", () => {
-        expect(true).toBe(true)
+beforeAll(async () => await db.connect())
+afterAll(async () => await db.closeDatabase())
+
+describe("API Tests - Single Tag Endpoints", () => {
+    test("Database has Tags Model", () => {
+        expect(TagsModel).toBeDefined()
+    })
+
+    test("GET - Retrieve a tag by id", async () => {
+        const data = tagsTestCases[0]
+        const tag = new TagsModel(data)
+        await tag.save()
+
+        expect(tag._id).toBeDefined() // Check if tag was created sucessfully
+
+        // Send request
+        const res = await request.get(`/api/tags/tag?id=${tag._id.valueOf()}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.title).toEqual(tag.title)
+        expect(new Date(res.body.created_at)).toEqual(tag.created_at)
+    })
+
+    test("POST - Add a new tag to database", async () => {
+        const data = tagsTestCases[15]
+
+        // Send request
+        const res = await request.post("/api/tags").send(data)
+
+        // Tests
+        expect(res.status).toEqual(201)
+        expect(res.body).toBeTruthy()
+        expect(res.body.data.title).toEqual(data.title)
+        expect(new Date(res.body.data.created_at)).toEqual(
+            new Date(data.created_at)
+        )
+    })
+
+    test("PATCH - /api/tags/tag", async () => {
+        const data = tagsTestCases[1]
+        const changeData = { title: "Dio", created_at: "03/01/2020" }
+        const tag = new TagsModel(data)
+        const retrievedTag = await tag.save()
+
+        // Send request
+        const res = await request
+            .patch(`/api/tags/tag/?id=${retrievedTag._id}`)
+            .send(changeData)
+
+        // Tests
+        expect(res.status).toEqual(202)
+        expect(res.body).toBeTruthy()
+
+        const updatedTag = await TagsModel.findById(retrievedTag._id)
+        expect(updatedTag.title).toEqual(changeData.title)
+        expect(updatedTag.created_at).toEqual(retrievedTag.created_at)
+    })
+
+    test("DELETE - Remove a tag from database by id", async () => {
+        const data = tagsTestCases[2]
+        const tag = new TagsModel(data)
+        const retrievedTag = await tag.save()
+
+        // Send request
+        const res = await request.delete(`/api/tags/tag?id=${retrievedTag._id}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        const deletedTag = await TagsModel.findOne({ title: data.title })
+        expect(deletedTag).toBeNull()
+    })
+
+    afterEach(async () => await db.clearDatabase())
+})
+
+describe("API Tests - Tags Pagination", () => {
+    test(`Fetch ${config.defaultPageSize} tag instances, page 1`, async () => {
+        // Create multiple tag instances. Initialize data in the first test
+        // Populated data is still available for following tests
+        await TagsModel.insertMany(tagsTestCases)
+
+        // Send request
+        const res = await request.get("/api/tags")
+
+        // Tests
+        const prevTag = await TagsModel.findById(res.body.cursors.prev)
+        const nextTag = await TagsModel.findById(res.body.cursors.next)
+
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(config.defaultPageSize)
+        expect(prevTag).toBeNull() // previous cursor should be null in first page
+        expect(nextTag).toBeTruthy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < res.body.data.length; i += 1) {
+            // Start from the last index of test cases list
+            const testCaseIndex = tagsTestCases.length - 1 - i
+
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[testCaseIndex].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[testCaseIndex].created_at)
+            )
+        }
+    })
+
+    test(`Fetch next ${config.defaultPageSize} tag instances, from page 1 to 2`, async () => {
+        // Get 10th tag by descending order
+        const next = await TagsModel.findOne().sort({ _id: -1 }).skip(9)
+        expect(next).toBeTruthy()
+
+        // Send request
+        const res = await request.get(`/api/tags/?next=${next._id}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(config.defaultPageSize)
+
+        const prevTag = await TagsModel.findById(res.body.cursors.prev)
+        const nextTag = await TagsModel.findById(res.body.cursors.next)
+
+        expect(prevTag).toBeTruthy()
+        expect(nextTag).toBeTruthy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < res.body.data.length; i += 1) {
+            // Start from last 11th index from the last index test cases list
+            const testCaseIndex =
+                tagsTestCases.length - config.defaultPageSize - 1 - i
+
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[testCaseIndex].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[testCaseIndex].created_at)
+            )
+        }
+    })
+
+    test(`Fetch prev ${config.defaultPageSize} tag instances, from page 3 to 2`, async () => {
+        // Get 10th tag by descending order
+        const prev = await TagsModel.findOne().sort({ _id: -1 }).skip(19)
+        expect(prev).toBeTruthy()
+
+        // Send request
+        const res = await request.get(`/api/tags/?next=${prev._id}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(config.defaultPageSize)
+
+        const prevTag = await TagsModel.findById(res.body.cursors.prev)
+        const nextTag = await TagsModel.findById(res.body.cursors.next)
+
+        expect(prevTag).toBeTruthy()
+        expect(nextTag).toBeTruthy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < res.body.data.length; i += 1) {
+            // Start from last 11th index from the last index test cases list
+            const testCaseIndex =
+                tagsTestCases.length - config.defaultPageSize * 2 - 1 - i
+
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[testCaseIndex].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[testCaseIndex].created_at)
+            )
+        }
+    })
+
+    test(`Fetch tag instances from the last page`, async () => {
+        // Calculate last page size. Expect from 1 to pagesize
+        const size = tagsTestCases.length % config.defaultPageSize
+        const actualSize = size !== 0 ? size : config.defaultPageSize
+
+        // Send request
+        const res = await request.get(`/api/tags/?last=true`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(actualSize)
+
+        const prevTag = await TagsModel.exists({ _id: res.body.cursors.prev })
+        const nextTag = await TagsModel.exists({ _id: res.body.cursors.next })
+
+        expect(prevTag).toBeTruthy()
+        expect(nextTag).toBeFalsy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < actualSize; i += 1) {
+            // Start from last 11th index from the last index test cases list
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[actualSize - i - 1].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[actualSize - i - 1].created_at)
+            )
+        }
+    })
+
+    test(`Fetch tag instances with more than default ${config.defaultPageSize} items per page`, async () => {
+        // Query size from frontend can be 10 | 20 | 30 | 40 | 50 .. items per page
+        const querySize = 30
+
+        // Send request
+        const res = await request.get(`/api/tags/?size=${querySize}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(querySize)
+
+        const prevTag = await TagsModel.exists({ _id: res.body.cursors.prev })
+        const nextTag = await TagsModel.exists({ _id: res.body.cursors.next })
+
+        expect(prevTag).toBeFalsy()
+        expect(nextTag).toBeTruthy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < querySize; i += 1) {
+            // Start from last 11th index from the last index test cases list
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[tagsTestCases.length - i - 1].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[tagsTestCases.length - i - 1].created_at)
+            )
+        }
+    })
+
+    test(`Fetch tag instances with more than maximum ${config.defaultMaxPageSize} items per page`, async () => {
+        // Calculate last page size. Expect from 1 to pagesize
+        const maxSize = config.defaultMaxPageSize
+
+        // Send request
+        const res = await request.get(`/api/tags/?size=${maxSize + 17}`)
+
+        // Tests
+        expect(res.status).toEqual(200)
+        expect(res.body).toBeTruthy()
+        expect(res.body.total).toEqual(tagsTestCases.length)
+        expect(res.body.size).toEqual(maxSize)
+
+        const prevTag = await TagsModel.exists({ _id: res.body.cursors.prev })
+        const nextTag = await TagsModel.exists({ _id: res.body.cursors.next })
+
+        expect(prevTag).toBeFalsy()
+        expect(nextTag).toBeTruthy()
+
+        // Check every retrieved instance
+        for (let i = 0; i < maxSize; i += 1) {
+            // Start from last index
+            expect(res.body.data[i].title).toEqual(
+                tagsTestCases[tagsTestCases.length - i - 1].title
+            )
+            expect(new Date(res.body.data[i].created_at)).toEqual(
+                new Date(tagsTestCases[tagsTestCases.length - i - 1].created_at)
+            )
+        }
     })
 })

--- a/backend/utils/test/data/tags.data.json
+++ b/backend/utils/test/data/tags.data.json
@@ -1,0 +1,638 @@
+[
+    {
+        "title": "donec",
+        "created_at": "12/23/2022"
+    },
+    {
+        "title": "venenatis",
+        "created_at": "03/09/2023"
+    },
+    {
+        "title": "dapibus",
+        "created_at": "03/17/2020"
+    },
+    {
+        "title": "nibh",
+        "created_at": "02/19/2020"
+    },
+    {
+        "title": "semper",
+        "created_at": "04/05/2020"
+    },
+    {
+        "title": "duis",
+        "created_at": "07/30/2022"
+    },
+    {
+        "title": "felis",
+        "created_at": "02/01/2021"
+    },
+    {
+        "title": "augue",
+        "created_at": "08/17/2021"
+    },
+    {
+        "title": "curabitur",
+        "created_at": "07/17/2020"
+    },
+    {
+        "title": "non",
+        "created_at": "03/09/2020"
+    },
+    {
+        "title": "lobortis",
+        "created_at": "04/16/2020"
+    },
+    {
+        "title": "rhoncus",
+        "created_at": "11/01/2022"
+    },
+    {
+        "title": "turpis",
+        "created_at": "10/23/2021"
+    },
+    {
+        "title": "quis",
+        "created_at": "02/09/2022"
+    },
+    {
+        "title": "tortor",
+        "created_at": "10/16/2022"
+    },
+    {
+        "title": "dui",
+        "created_at": "09/22/2021"
+    },
+    {
+        "title": "ipsum",
+        "created_at": "12/13/2020"
+    },
+    {
+        "title": "tincidunt",
+        "created_at": "04/15/2020"
+    },
+    {
+        "title": "id",
+        "created_at": "03/01/2020"
+    },
+    {
+        "title": "velit",
+        "created_at": "06/06/2020"
+    },
+    {
+        "title": "sodales",
+        "created_at": "04/11/2021"
+    },
+    {
+        "title": "sem",
+        "created_at": "11/03/2022"
+    },
+    {
+        "title": "tempus",
+        "created_at": "10/29/2020"
+    },
+    {
+        "title": "hac",
+        "created_at": "02/16/2020"
+    },
+    {
+        "title": "iaculis",
+        "created_at": "01/04/2023"
+    },
+    {
+        "title": "metus",
+        "created_at": "07/03/2022"
+    },
+    {
+        "title": "platea",
+        "created_at": "01/18/2023"
+    },
+    {
+        "title": "convallis",
+        "created_at": "05/14/2020"
+    },
+    {
+        "title": "sit",
+        "created_at": "06/07/2020"
+    },
+    {
+        "title": "amet",
+        "created_at": "04/01/2022"
+    },
+    {
+        "title": "neque",
+        "created_at": "04/15/2021"
+    },
+    {
+        "title": "vitae",
+        "created_at": "02/22/2021"
+    },
+    {
+        "title": "proin",
+        "created_at": "01/06/2021"
+    },
+    {
+        "title": "ac",
+        "created_at": "12/07/2020"
+    },
+    {
+        "title": "vestibulum",
+        "created_at": "01/19/2021"
+    },
+    {
+        "title": "suspendisse",
+        "created_at": "08/05/2021"
+    },
+    {
+        "title": "erat",
+        "created_at": "11/25/2020"
+    },
+    {
+        "title": "lectus",
+        "created_at": "11/01/2021"
+    },
+    {
+        "title": "morbi",
+        "created_at": "12/04/2020"
+    },
+    {
+        "title": "sed",
+        "created_at": "06/28/2020"
+    },
+    {
+        "title": "mattis",
+        "created_at": "11/01/2020"
+    },
+    {
+        "title": "eu",
+        "created_at": "08/25/2022"
+    },
+    {
+        "title": "in",
+        "created_at": "01/28/2023"
+    },
+    {
+        "title": "vulputate",
+        "created_at": "06/04/2022"
+    },
+    {
+        "title": "mi",
+        "created_at": "01/27/2020"
+    },
+    {
+        "title": "pede",
+        "created_at": "09/02/2020"
+    },
+    {
+        "title": "faucibus",
+        "created_at": "02/22/2023"
+    },
+    {
+        "title": "euismod",
+        "created_at": "09/15/2020"
+    },
+    {
+        "title": "nisi",
+        "created_at": "01/22/2021"
+    },
+    {
+        "title": "quam",
+        "created_at": "07/23/2022"
+    },
+    {
+        "title": "enim",
+        "created_at": "03/09/2020"
+    },
+    {
+        "title": "parturient",
+        "created_at": "12/06/2022"
+    },
+    {
+        "title": "justo",
+        "created_at": "02/05/2023"
+    },
+    {
+        "title": "habitasse",
+        "created_at": "05/19/2022"
+    },
+    {
+        "title": "sapien",
+        "created_at": "11/11/2020"
+    },
+    {
+        "title": "lacinia",
+        "created_at": "06/29/2021"
+    },
+    {
+        "title": "vel",
+        "created_at": "01/25/2021"
+    },
+    {
+        "title": "luctus",
+        "created_at": "05/16/2021"
+    },
+    {
+        "title": "sollicitudin",
+        "created_at": "01/02/2020"
+    },
+    {
+        "title": "leo",
+        "created_at": "09/26/2021"
+    },
+    {
+        "title": "cum",
+        "created_at": "02/10/2023"
+    },
+    {
+        "title": "praesent",
+        "created_at": "05/26/2021"
+    },
+    {
+        "title": "interdum",
+        "created_at": "08/08/2022"
+    },
+    {
+        "title": "integer",
+        "created_at": "02/16/2021"
+    },
+    {
+        "title": "vehicula",
+        "created_at": "10/12/2021"
+    },
+    {
+        "title": "elit",
+        "created_at": "01/18/2021"
+    },
+    {
+        "title": "maecenas",
+        "created_at": "04/25/2022"
+    },
+    {
+        "title": "mollis",
+        "created_at": "10/11/2020"
+    },
+    {
+        "title": "mauris",
+        "created_at": "09/26/2021"
+    },
+    {
+        "title": "libero",
+        "created_at": "08/30/2021"
+    },
+    {
+        "title": "nisl",
+        "created_at": "10/05/2022"
+    },
+    {
+        "title": "mus",
+        "created_at": "07/21/2020"
+    },
+    {
+        "title": "eget",
+        "created_at": "03/12/2021"
+    },
+    {
+        "title": "ut",
+        "created_at": "11/04/2022"
+    },
+    {
+        "title": "nulla",
+        "created_at": "12/12/2020"
+    },
+    {
+        "title": "a",
+        "created_at": "08/22/2022"
+    },
+    {
+        "title": "orci",
+        "created_at": "06/04/2021"
+    },
+    {
+        "title": "ultrices",
+        "created_at": "05/31/2022"
+    },
+    {
+        "title": "penatibus",
+        "created_at": "08/28/2021"
+    },
+    {
+        "title": "nec",
+        "created_at": "10/17/2021"
+    },
+    {
+        "title": "tellus",
+        "created_at": "09/30/2021"
+    },
+    {
+        "title": "aliquam",
+        "created_at": "07/12/2020"
+    },
+    {
+        "title": "dis",
+        "created_at": "04/07/2022"
+    },
+    {
+        "title": "imperdiet",
+        "created_at": "02/20/2020"
+    },
+    {
+        "title": "at",
+        "created_at": "11/10/2021"
+    },
+    {
+        "title": "tristique",
+        "created_at": "02/24/2021"
+    },
+    {
+        "title": "et",
+        "created_at": "08/03/2022"
+    },
+    {
+        "title": "est",
+        "created_at": "05/16/2020"
+    },
+    {
+        "title": "pretium",
+        "created_at": "09/07/2021"
+    },
+    {
+        "title": "cras",
+        "created_at": "10/18/2021"
+    },
+    {
+        "title": "cubilia",
+        "created_at": "11/24/2020"
+    },
+    {
+        "title": "sociis",
+        "created_at": "05/20/2021"
+    },
+    {
+        "title": "porttitor",
+        "created_at": "10/31/2020"
+    },
+    {
+        "title": "etiam",
+        "created_at": "09/14/2021"
+    },
+    {
+        "title": "scelerisque",
+        "created_at": "12/14/2022"
+    },
+    {
+        "title": "pellentesque",
+        "created_at": "11/05/2020"
+    },
+    {
+        "title": "sagittis",
+        "created_at": "08/21/2021"
+    },
+    {
+        "title": "molestie",
+        "created_at": "08/20/2021"
+    },
+    {
+        "title": "rutrum",
+        "created_at": "05/24/2022"
+    },
+    {
+        "title": "dictumst",
+        "created_at": "11/18/2022"
+    },
+    {
+        "title": "risus",
+        "created_at": "06/30/2021"
+    },
+    {
+        "title": "ridiculus",
+        "created_at": "08/22/2020"
+    },
+    {
+        "title": "purus",
+        "created_at": "12/26/2022"
+    },
+    {
+        "title": "curae",
+        "created_at": "06/22/2022"
+    },
+    {
+        "title": "primis",
+        "created_at": "06/09/2020"
+    },
+    {
+        "title": "bibendum",
+        "created_at": "09/05/2022"
+    },
+    {
+        "title": "eleifend",
+        "created_at": "10/04/2021"
+    },
+    {
+        "title": "volutpat",
+        "created_at": "11/10/2021"
+    },
+    {
+        "title": "fusce",
+        "created_at": "01/24/2021"
+    },
+    {
+        "title": "massa",
+        "created_at": "05/11/2021"
+    },
+    {
+        "title": "gravida",
+        "created_at": "08/17/2022"
+    },
+    {
+        "title": "ornare",
+        "created_at": "10/21/2021"
+    },
+    {
+        "title": "lacus",
+        "created_at": "10/26/2021"
+    },
+    {
+        "title": "dolor",
+        "created_at": "01/25/2022"
+    },
+    {
+        "title": "nullam",
+        "created_at": "05/27/2022"
+    },
+    {
+        "title": "consequat",
+        "created_at": "10/08/2020"
+    },
+    {
+        "title": "ligula",
+        "created_at": "01/13/2020"
+    },
+    {
+        "title": "condimentum",
+        "created_at": "04/26/2022"
+    },
+    {
+        "title": "consectetuer",
+        "created_at": "09/14/2020"
+    },
+    {
+        "title": "adipiscing",
+        "created_at": "02/01/2023"
+    },
+    {
+        "title": "quisque",
+        "created_at": "02/08/2020"
+    },
+    {
+        "title": "viverra",
+        "created_at": "09/25/2020"
+    },
+    {
+        "title": "urna",
+        "created_at": "05/13/2022"
+    },
+    {
+        "title": "posuere",
+        "created_at": "01/05/2022"
+    },
+    {
+        "title": "ante",
+        "created_at": "07/08/2020"
+    },
+    {
+        "title": "odio",
+        "created_at": "05/05/2020"
+    },
+    {
+        "title": "varius",
+        "created_at": "01/24/2022"
+    },
+    {
+        "title": "suscipit",
+        "created_at": "01/17/2021"
+    },
+    {
+        "title": "montes",
+        "created_at": "06/08/2021"
+    },
+    {
+        "title": "diam",
+        "created_at": "11/13/2021"
+    },
+    {
+        "title": "pulvinar",
+        "created_at": "10/13/2020"
+    },
+    {
+        "title": "feugiat",
+        "created_at": "05/28/2021"
+    },
+    {
+        "title": "nam",
+        "created_at": "03/20/2020"
+    },
+    {
+        "title": "magna",
+        "created_at": "08/03/2020"
+    },
+    {
+        "title": "blandit",
+        "created_at": "11/02/2022"
+    },
+    {
+        "title": "lorem",
+        "created_at": "06/05/2020"
+    },
+    {
+        "title": "nascetur",
+        "created_at": "04/03/2021"
+    },
+    {
+        "title": "eros",
+        "created_at": "12/06/2020"
+    },
+    {
+        "title": "fringilla",
+        "created_at": "08/03/2021"
+    },
+    {
+        "title": "nunc",
+        "created_at": "11/10/2021"
+    },
+    {
+        "title": "arcu",
+        "created_at": "03/27/2020"
+    },
+    {
+        "title": "aenean",
+        "created_at": "01/09/2020"
+    },
+    {
+        "title": "elementum",
+        "created_at": "11/10/2021"
+    },
+    {
+        "title": "facilisi",
+        "created_at": "08/05/2021"
+    },
+    {
+        "title": "vivamus",
+        "created_at": "04/05/2022"
+    },
+    {
+        "title": "placerat",
+        "created_at": "01/06/2022"
+    },
+    {
+        "title": "pharetra",
+        "created_at": "12/26/2021"
+    },
+    {
+        "title": "potenti",
+        "created_at": "08/14/2020"
+    },
+    {
+        "title": "fermentum",
+        "created_at": "04/29/2020"
+    },
+    {
+        "title": "aliquet",
+        "created_at": "09/01/2022"
+    },
+    {
+        "title": "auctor",
+        "created_at": "02/12/2020"
+    },
+    {
+        "title": "ultricies",
+        "created_at": "12/09/2021"
+    },
+    {
+        "title": "nonummy",
+        "created_at": "10/27/2020"
+    },
+    {
+        "title": "natoque",
+        "created_at": "06/05/2020"
+    },
+    {
+        "title": "ullamcorper",
+        "created_at": "12/04/2020"
+    },
+    {
+        "title": "congue",
+        "created_at": "02/06/2023"
+    },
+    {
+        "title": "phasellus",
+        "created_at": "12/05/2022"
+    },
+    {
+        "title": "accumsan",
+        "created_at": "07/05/2020"
+    },
+    {
+        "title": "cursus",
+        "created_at": "12/11/2021"
+    }
+]

--- a/backend/utils/test/db-test-setup.js
+++ b/backend/utils/test/db-test-setup.js
@@ -8,7 +8,6 @@ let mongod
 module.exports.connect = async () => {
     mongod = await MongoMemoryServer.create()
     const uri = mongod.getUri()
-
     mongoose.connect(uri, {
         dbName: "cs_club_test",
         useNewUrlParser: true,


### PR DESCRIPTION
This PR modifies getAll function into a paginating controller function to efficient query data instead of retrieve all pieces of data. The function use cursor pagination for efficient query instead of using offset (skip in mongoose). Add three routes for tags model: get single, get all, and post (for create a tag). 

Progress:
- [x]  getAll cursor pagination, get and post routes for tags, and add default date for tag model
- [x] write test pagination for tags


UPDATE

This PR includes multiple changes
- add cursor pagination in getAll function for faster query (for scrolling pagination and batch size). Cursor pagination won't handle random page access. This should handle by query in batch and send to the frontend, which will handle random access
- implement all other functions of controller frameworks (get, create, update, delete)
- separate index.js into app.js which only stores api routes for avoid conflict when connecting to test db collections and main db collections while testing
- add test cases for tags api. add tags test data
- relocate db test connector to utils
- some changes in the tags model. Tags title now is unique to prevent accidental changes to a tag that has the same title as the existing one.

Notes: This PR may need multiple reviewers.

Solved #117, #118, #119, #120
