### PR TITLE
add host & port in vite to be runnable on docker

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -31,7 +31,7 @@ export default defineConfig({
 	},
 	server: {
 		host: true,
-		port: 3000
+		port: 3000,
 	},
 	plugins: [
 		react(),

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -29,6 +29,10 @@ export default defineConfig({
 			module: true,
 		},
 	},
+	server: {
+		host: true,
+		port: 3000
+	},
 	plugins: [
 		react(),
 		visualizer({


### PR DESCRIPTION
The default port in vite config didn't match `docker-compose.yaml`. Change port to 3000.
Solved #127 